### PR TITLE
Fix broken exceptions AND allow extending client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1-alpha.1
+
+* Expose doApiRequest method so that RestApiClient may be extended by users.
+* Fix broken OrderBook.aggregatedSnapshot method. sortPublicOrders now returns a List.
+
 ## 0.1.0-alpha.2
 
 * Documentation fixes.

--- a/example/main.dart
+++ b/example/main.dart
@@ -49,8 +49,7 @@ main() {
     var btcusdVwap = results[7];
     var bitfinex = results[8];
     var bitfinexBtcUsd = results[9];
-    var snapshot = results[10];
-    var book = sdk.OrderBook.fromSnapshot(snapshot);
+    var book = results[10];
     var candles = results[11];
     var summary = results[12];
     var price = results[13];
@@ -81,7 +80,7 @@ main() {
     print(btcusdVwap);
     print(bitfinex);
     print(bitfinexBtcUsd);
-    print(snapshot);
+    print(book.snapshot);
     print(book.aggregatedSnapshot(10000));
     print(candles);
     print(summary);

--- a/lib/src/client/rest/rest.dart
+++ b/lib/src/client/rest/rest.dart
@@ -40,8 +40,11 @@ class RestApiClient {
     this._httpClient = httpClient;
   }
 
-  Future<http.Response> _doApiRequest(String path,
-      [Map<String, String> params]) {
+  /// Returns a Future that resolves to an HTTP response.
+  ///
+  /// This method may be used to extend the API client.
+  Future<http.Response> doApiRequest(String path,
+      {Map<String, String> params}) {
     if (params != null && params.length == 0) {
       params = null;
     }
@@ -71,7 +74,7 @@ class RestApiClient {
   /// Returns a Future that resolves to an iterable collection of all assets.
   Future<Iterable<common.Asset>> fetchAssets() {
     var ret = Future(() {
-      var respFuture = this._doApiRequest("assets");
+      var respFuture = this.doApiRequest("assets");
       return respFuture.then((resp) {
         var unparsedAssetList = _getResultAsIterable(resp.body);
         var assetList = List<common.Asset>();
@@ -90,7 +93,7 @@ class RestApiClient {
   /// Returns a Future that resolves to the asset with symbol [sym].
   Future<common.Asset> fetchAsset(String sym) {
     var ret = Future(() {
-      var respFuture = this._doApiRequest("assets/${Uri.encodeComponent(sym)}");
+      var respFuture = this.doApiRequest("assets/${Uri.encodeComponent(sym)}");
       return respFuture.then((resp) {
         if (resp.statusCode == _statusCodeNotFound) {
           return null;
@@ -107,7 +110,7 @@ class RestApiClient {
   /// Returns a Future that resolves to an iterable collection of all asset pairs.
   Future<Iterable<common.Pair>> fetchPairs() {
     var ret = Future(() {
-      var respFuture = this._doApiRequest("pairs");
+      var respFuture = this.doApiRequest("pairs");
       return respFuture.then((resp) {
         var unparsedPairList = _getResultAsIterable(resp.body);
         var pairList = List<common.Pair>();
@@ -126,7 +129,7 @@ class RestApiClient {
   /// Returns a Future that resolves to the pair with symbol [sym].
   Future<common.Pair> fetchPair(String sym) {
     var ret = Future(() {
-      var respFuture = this._doApiRequest("pairs/${Uri.encodeComponent(sym)}");
+      var respFuture = this.doApiRequest("pairs/${Uri.encodeComponent(sym)}");
       return respFuture.then((resp) {
         if (resp.statusCode == _statusCodeNotFound) {
           return null;
@@ -143,7 +146,7 @@ class RestApiClient {
   /// Returns a Future that resolves to the vwap for the pair with symbol [sym].
   Future<num> fetchPairVwap(String sym) {
     var ret = Future(() {
-      var respFuture = this._doApiRequest(
+      var respFuture = this.doApiRequest(
         "pairs/${Uri.encodeComponent(sym)}/vwap",
       );
 
@@ -170,7 +173,7 @@ class RestApiClient {
   /// Returns a Future that resolves to an iterable collection of all exchanges.
   Future<List<common.Exchange>> fetchExchanges() {
     var ret = Future(() {
-      var respFuture = this._doApiRequest("exchanges");
+      var respFuture = this.doApiRequest("exchanges");
       return respFuture.then((resp) {
         var unparsedExchangeList = _getResultAsIterable(resp.body);
         var exchangeList = List<common.Exchange>();
@@ -190,7 +193,7 @@ class RestApiClient {
   Future<common.Exchange> fetchExchange(String sym) {
     var ret = Future(() {
       var respFuture =
-          this._doApiRequest("exchanges/${Uri.encodeComponent(sym)}");
+          this.doApiRequest("exchanges/${Uri.encodeComponent(sym)}");
       return respFuture.then((resp) {
         if (resp.statusCode == _statusCodeNotFound) {
           return null;
@@ -215,7 +218,7 @@ class RestApiClient {
         path += "/${Uri.encodeComponent(exchange)}";
       }
 
-      var respFuture = this._doApiRequest(path);
+      var respFuture = this.doApiRequest(path);
       return respFuture.then((resp) {
         var unparsedMarketList = _getResultAsIterable(resp.body);
         var marketList = List<common.Market>();
@@ -238,7 +241,7 @@ class RestApiClient {
       exchangeSym = Uri.encodeComponent(exchangeSym);
       pairSym = Uri.encodeComponent(pairSym);
 
-      var respFuture = this._doApiRequest("markets/${exchangeSym}/${pairSym}");
+      var respFuture = this.doApiRequest("markets/${exchangeSym}/${pairSym}");
       return respFuture.then((resp) {
         if (resp.statusCode == _statusCodeNotFound) {
           return null;
@@ -260,7 +263,7 @@ class RestApiClient {
       pairSym = Uri.encodeComponent(pairSym);
 
       var path = "markets/${exchangeSym}/${pairSym}/orderbook";
-      var respFuture = this._doApiRequest(path);
+      var respFuture = this.doApiRequest(path);
 
       return respFuture.then((resp) {
         if (resp.statusCode == _statusCodeNotFound) {
@@ -309,7 +312,7 @@ class RestApiClient {
       pairSym = Uri.encodeComponent(pairSym);
 
       var path = "markets/${exchangeSym}/${pairSym}/ohlc";
-      var respFuture = this._doApiRequest(path, params);
+      var respFuture = this.doApiRequest(path, params: params);
 
       return respFuture.then((resp) {
         if (resp.statusCode == _statusCodeNotFound) {
@@ -338,7 +341,7 @@ class RestApiClient {
       pairSym = Uri.encodeComponent(pairSym);
 
       var path = "markets/${exchangeSym}/${pairSym}/summary";
-      var respFuture = this._doApiRequest(path);
+      var respFuture = this.doApiRequest(path);
 
       return respFuture.then((resp) {
         if (resp.statusCode == _statusCodeNotFound) {
@@ -361,7 +364,7 @@ class RestApiClient {
       pairSym = Uri.encodeComponent(pairSym);
 
       var path = "markets/${exchangeSym}/${pairSym}/price";
-      var respFuture = this._doApiRequest(path);
+      var respFuture = this.doApiRequest(path);
 
       return respFuture.then((resp) {
         if (resp.statusCode == _statusCodeNotFound) {
@@ -410,7 +413,7 @@ class RestApiClient {
       pairSym = Uri.encodeComponent(pairSym);
 
       var path = "markets/${exchangeSym}/${pairSym}/trades";
-      var respFuture = this._doApiRequest(path, params);
+      var respFuture = this.doApiRequest(path, params: params);
 
       return respFuture.then((resp) {
         if (resp.statusCode == _statusCodeNotFound) {

--- a/lib/src/common/order_book.dart
+++ b/lib/src/common/order_book.dart
@@ -23,8 +23,8 @@ class OrderBookSnapshot {
   /// [asks] and [bids] PublicOrders. Optionally a [seqNum] can be passed.
   OrderBookSnapshot(Iterable<PublicOrder> asks, Iterable<PublicOrder> bids,
       [this.seqNum = 0]) {
-    sortPublicOrders(asks);
-    sortPublicOrders(bids);
+    asks = sortPublicOrders(asks);
+    bids = sortPublicOrders(bids);
 
     this.asks.addAll(asks);
     this.bids.addAll(bids);
@@ -147,9 +147,7 @@ class OrderBook {
   /// Returns a sorted iterable set of all asks.
   Iterable<PublicOrder> get asks {
     var orders = this._asks.entries.map((entry) => entry.value).toList();
-    sortPublicOrders(orders);
-
-    return orders;
+    return sortPublicOrders(orders);
   }
 
   set asks(Iterable<PublicOrder> orders) {
@@ -168,9 +166,7 @@ class OrderBook {
   /// Returns a sorted iterable set of all bids.
   Iterable<PublicOrder> get bids {
     var orders = this._bids.entries.map((entry) => entry.value).toList();
-    sortPublicOrders(orders);
-
-    return orders;
+    return sortPublicOrders(orders);
   }
 
   set bids(Iterable<PublicOrder> orders) {

--- a/lib/src/common/public_order.dart
+++ b/lib/src/common/public_order.dart
@@ -53,8 +53,11 @@ class PublicOrder {
 }
 
 // sort public orders in either ascending (default) or descending price order.
-sortPublicOrders(List<PublicOrder> orders, [bool asc = true]) {
-  orders.sort((a, b) {
+List<PublicOrder> sortPublicOrders(Iterable<PublicOrder> orders,
+    [bool asc = true]) {
+  final ordersList = orders.toList();
+
+  ordersList.sort((a, b) {
     if (a.price < b.price) {
       return (asc) ? -1 : 1;
     } else if (a.price > b.price) {
@@ -63,6 +66,8 @@ sortPublicOrders(List<PublicOrder> orders, [bool asc = true]) {
       return 0;
     }
   });
+
+  return ordersList;
 }
 
 // aggregates orders at certain price levels.


### PR DESCRIPTION
## Description

Cryptowatch may add new endpoints in the feature, by exposing `RestApiClient.doApiRequest` users can now extend the client by doing something like:

```
class ApiClient extends RestApiClient {
    RestApiClient({
        http.Client httpClient,
        String apiDomain,
        String apiKey,
    }): super(httpClient: httpClient, apiDomain: apiDomain, apiKey: apiKey);
 
    Future<Bar> fetchFoo() async {
        var resp = await this.doApiRequest('/foo', null);
        return parseBar(resp);
    }
}

Bar parseBar(http.Response resp) {
    ...
}
```

Furthermore there were exceptions being thrown from `examples/main.dart` I've resolved those, mainly by making `sortPublicOrders` return a list.

## Type of Change

[x] New Feature
[x] Bug Fix